### PR TITLE
Micropostsリソースの追加

### DIFF
--- a/app/assets/stylesheets/microposts.scss
+++ b/app/assets/stylesheets/microposts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Microposts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -1,0 +1,74 @@
+class MicropostsController < ApplicationController
+  before_action :set_micropost, only: [:show, :edit, :update, :destroy]
+
+  # GET /microposts
+  # GET /microposts.json
+  def index
+    @microposts = Micropost.all
+  end
+
+  # GET /microposts/1
+  # GET /microposts/1.json
+  def show
+  end
+
+  # GET /microposts/new
+  def new
+    @micropost = Micropost.new
+  end
+
+  # GET /microposts/1/edit
+  def edit
+  end
+
+  # POST /microposts
+  # POST /microposts.json
+  def create
+    @micropost = Micropost.new(micropost_params)
+
+    respond_to do |format|
+      if @micropost.save
+        format.html { redirect_to @micropost, notice: 'Micropost was successfully created.' }
+        format.json { render :show, status: :created, location: @micropost }
+      else
+        format.html { render :new }
+        format.json { render json: @micropost.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /microposts/1
+  # PATCH/PUT /microposts/1.json
+  def update
+    respond_to do |format|
+      if @micropost.update(micropost_params)
+        format.html { redirect_to @micropost, notice: 'Micropost was successfully updated.' }
+        format.json { render :show, status: :ok, location: @micropost }
+      else
+        format.html { render :edit }
+        format.json { render json: @micropost.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /microposts/1
+  # DELETE /microposts/1.json
+  def destroy
+    @micropost.destroy
+    respond_to do |format|
+      format.html { redirect_to microposts_url, notice: 'Micropost was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_micropost
+      @micropost = Micropost.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def micropost_params
+      params.require(:micropost).permit(:content, :user_id)
+    end
+end

--- a/app/helpers/microposts_helper.rb
+++ b/app/helpers/microposts_helper.rb
@@ -1,0 +1,2 @@
+module MicropostsHelper
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,0 +1,2 @@
+class Micropost < ApplicationRecord
+end

--- a/app/views/microposts/_form.html.erb
+++ b/app/views/microposts/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: micropost, local: true) do |form| %>
+  <% if micropost.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(micropost.errors.count, "error") %> prohibited this micropost from being saved:</h2>
+
+      <ul>
+        <% micropost.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="field">
+    <%= form.label :user_id %>
+    <%= form.number_field :user_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/microposts/_micropost.json.jbuilder
+++ b/app/views/microposts/_micropost.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! micropost, :id, :content, :user_id, :created_at, :updated_at
+json.url micropost_url(micropost, format: :json)

--- a/app/views/microposts/edit.html.erb
+++ b/app/views/microposts/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Micropost</h1>
+
+<%= render 'form', micropost: @micropost %>
+
+<%= link_to 'Show', @micropost %> |
+<%= link_to 'Back', microposts_path %>

--- a/app/views/microposts/index.html.erb
+++ b/app/views/microposts/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Microposts</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Content</th>
+      <th>User</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @microposts.each do |micropost| %>
+      <tr>
+        <td><%= micropost.content %></td>
+        <td><%= micropost.user_id %></td>
+        <td><%= link_to 'Show', micropost %></td>
+        <td><%= link_to 'Edit', edit_micropost_path(micropost) %></td>
+        <td><%= link_to 'Destroy', micropost, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Micropost', new_micropost_path %>

--- a/app/views/microposts/index.json.jbuilder
+++ b/app/views/microposts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @microposts, partial: "microposts/micropost", as: :micropost

--- a/app/views/microposts/new.html.erb
+++ b/app/views/microposts/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Micropost</h1>
+
+<%= render 'form', micropost: @micropost %>
+
+<%= link_to 'Back', microposts_path %>

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Content:</strong>
+  <%= @micropost.content %>
+</p>
+
+<p>
+  <strong>User:</strong>
+  <%= @micropost.user_id %>
+</p>
+
+<%= link_to 'Edit', edit_micropost_path(@micropost) %> |
+<%= link_to 'Back', microposts_path %>

--- a/app/views/microposts/show.json.jbuilder
+++ b/app/views/microposts/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "microposts/micropost", micropost: @micropost

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+  resources :microposts
   resources :users
   root 'users#index'
 end

--- a/db/migrate/20210115035114_create_microposts.rb
+++ b/db/migrate/20210115035114_create_microposts.rb
@@ -1,0 +1,10 @@
+class CreateMicroposts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :microposts do |t|
+      t.text :content
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_15_004159) do
+ActiveRecord::Schema.define(version: 2021_01_15_035114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "microposts", force: :cascade do |t|
+    t.text "content"
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name"

--- a/test/controllers/microposts_controller_test.rb
+++ b/test/controllers/microposts_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class MicropostsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @micropost = microposts(:one)
+  end
+
+  test "should get index" do
+    get microposts_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_micropost_url
+    assert_response :success
+  end
+
+  test "should create micropost" do
+    assert_difference('Micropost.count') do
+      post microposts_url, params: { micropost: { content: @micropost.content, user_id: @micropost.user_id } }
+    end
+
+    assert_redirected_to micropost_url(Micropost.last)
+  end
+
+  test "should show micropost" do
+    get micropost_url(@micropost)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_micropost_url(@micropost)
+    assert_response :success
+  end
+
+  test "should update micropost" do
+    patch micropost_url(@micropost), params: { micropost: { content: @micropost.content, user_id: @micropost.user_id } }
+    assert_redirected_to micropost_url(@micropost)
+  end
+
+  test "should destroy micropost" do
+    assert_difference('Micropost.count', -1) do
+      delete micropost_url(@micropost)
+    end
+
+    assert_redirected_to microposts_url
+  end
+end

--- a/test/fixtures/microposts.yml
+++ b/test/fixtures/microposts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+  user_id: 1
+
+two:
+  content: MyText
+  user_id: 1

--- a/test/models/micropost_test.rb
+++ b/test/models/micropost_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MicropostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/microposts_test.rb
+++ b/test/system/microposts_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class MicropostsTest < ApplicationSystemTestCase
+  setup do
+    @micropost = microposts(:one)
+  end
+
+  test "visiting the index" do
+    visit microposts_url
+    assert_selector "h1", text: "Microposts"
+  end
+
+  test "creating a Micropost" do
+    visit microposts_url
+    click_on "New Micropost"
+
+    fill_in "Content", with: @micropost.content
+    fill_in "User", with: @micropost.user_id
+    click_on "Create Micropost"
+
+    assert_text "Micropost was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Micropost" do
+    visit microposts_url
+    click_on "Edit", match: :first
+
+    fill_in "Content", with: @micropost.content
+    fill_in "User", with: @micropost.user_id
+    click_on "Update Micropost"
+
+    assert_text "Micropost was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Micropost" do
+    visit microposts_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Micropost was successfully destroyed"
+  end
+end


### PR DESCRIPTION
### ユーザーモデルの設計

1. id：integer型
2. content：text型
3. user_id：integer型

### scaffoldジェネレータで生成

`$ rails generate scaffold Micropost content:text user_id:integer`

### マイグレーションで追加テーブルを登録
`$ rails db:migrate`

↑ データベースを更新してmicropostsデータモデルを追加。

### ユーザーページの構造（HTTPリクエスト　URL　アクション　用途）

- `GET`　 /microposts　`index`　すべてのマイクロポストを表示するページ
- `GET`　/microposts/1　`show`　id=1のマイクロポストを表示するページ
- `GET`　/microposts/new　`new`　マイクロポストを新規作成するページ
- `POST`　/microposts　`create`　マイクロポストを新規作成するアクション
- `GET`　/microposts/1/edit　`edit`　id=1のマイクロポストを編集するページ
- `PATCH`　/microposts/1　`update`　id=1のマイクロポストを更新するアクション
- `DELETE`　/microposts/1　`destroy`　id1のマイクロポストを削除する