### PR TITLE
micropostの文字制限

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,2 +1,3 @@
 class Micropost < ApplicationRecord
+    validates :content,length: { maximum: 140 }
 end


### PR DESCRIPTION
・contentに140文字以上入力するエラーになるバリテーションを追加（`app/models/micropost.rb`）

```
class Micropost < ApplicationRecord
  validates :content, length: { maximum: 140 }
end
```