### PR TITLE
カスタムcssの演習

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -67,3 +67,7 @@ p {
     color: #fff;
     text-decoration: none;
 }
+
+img {
+    display: none;
+}

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -12,4 +12,4 @@
 
 <%= link_to  image_tag("rails.svg", alt: "Rails logo", width: "200px"), "https://rubyonrails.org/" %>
 
-<%= image_tag  "kitten.jpg" %>
+<%#= image_tag  "kitten.jpg" %>


### PR DESCRIPTION
> リスト 5.10を参考にして、5.1.1.1で使ったネコ画像をコメントアウトしてみてください。また、ブラウザのHTMLインスペクタ機能を使って、コメントアウトするとHTMLのソースからも消えていることを確認してみてください。

`<%#= image_tag  "kitten.jpg" %>`

> リスト 5.11のコードをcustom.scssに追加し、すべての画像を非表示にしてみてください。うまくいけば、Railsのロゴ画像がHomeページから消えるはずです。先ほどと同様にインスペクタ機能を使って、今度はHTMLのソースコードは残ったままで、画像だけが表示されなくなっていることを確認してみてください。

→ 済