### PR TITLE
エラーメッセージの表示

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -161,4 +161,19 @@ input, textarea, select, .uneditable-input {
 input {
     height: auto !important;
 }
+
+#error_explanation {
+    color: red;
+    ul {
+        color: red;
+        margin: 0 0 30px 0;
+    }
+}
+  
+.field_with_errors {
+    @extend .has-error;
+    .form-control {
+        color: $state-danger-text;
+    }
+}
   

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @user.errors.any? %>
+<div id="error_explanation">
+    <div class="alert alert-danger">
+        The form contains <%= pluralize(@user.errors.count, "error") %>.
+    </div>
+    <ul>
+        <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+        <% end %>
+    </ul>
+</div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,17 +3,19 @@
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
         <%= form_with(model: @user, local: true) do |f| %>
+        <%= render "shared/error_messages" %>
+
         <%= f.label :name %>
-        <%= f.text_field :name %>
+        <%= f.text_field :name, class: "form-control" %>
 
         <%= f.label :email %>
-        <%= f.email_field :email %>
+        <%= f.email_field :email, class: "form-control" %>
 
         <%= f.label :password %>
-        <%= f.password_field :password %>
+        <%= f.password_field :password, class: "form-control" %>
 
         <%= f.label :password_confirmation, "Confirmation" %>
-        <%= f.password_field :password_confirmation %>
+        <%= f.password_field :password_confirmation, class: "form-control" %>
 
         <%= f.submit "Create my account", class: "btn btn-primary" %>
         <% end %>


### PR DESCRIPTION
**エラーメッセージの表示**

コンソールでエラーメッセージを確認したときの要領と同じように`user.errors.full_messages`を利用する。

- エラーメッセージをレンダリングする（`app/views/users/new.html.erb`）

```
<%= form_with(model: @user, local: true) do |f| %>
        <%= render "shared/error_messages" %>

        <%= f.label :name %>
        <%= f.text_field :name, class: "form-control" %>

        <%= f.label :email %>
        <%= f.email_field :email, class: "form-control" %>

        <%= f.label :password %>
        <%= f.password_field :password, class: "form-control" %>

        <%= f.label :password_confirmation, "Confirmation" %>
        <%= f.password_field :password_confirmation, class: "form-control" %>

        <%= f.submit "Create my account", class: "btn btn-primary" %>
<% end %>
```

`app/views/shared/_error_messages.html.erb`にあるエラーメッセージがレンダリングされるように追加する。

- エラーメッセージの表示（`app/views/shared/_error_messages.html.erb`）

```
<% if @user.errors.any? %>
<div id="error_explanation">
    <div class="alert alert-danger">
        The form contains <%= pluralize(@user.errors.count, "error") %>.
    </div>
    <ul>
        <% @user.errors.full_messages.each do |msg| %>
        <li><%= msg %></li>
        <% end %>
    </ul>
</div>
<% end %>
```

`@user.errors.any?`で入力情報に誤りがあるかどうかを判定する。

`pluralize`ヘルパーによってエラーの数（`@user.errors.count`）が表示される。

`each do`で`@user.errors.full_messages`をひとつずつ表示させている。