### PR TITLE
フォーム送信のテスト

### DIFF
--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class UsersSignupTest < ActionDispatch::IntegrationTest
+  
+  test "invalid signup information" do
+    get signup_path
+    assert_no_difference "User.count" do
+      post users_path, params: {
+        user: {
+          name: "",
+          email: "user@invalid",
+          password: "foo",
+          password_confirmation: "bar"
+        }
+      }
+    end
+    assert_template 'users/new'
+  end
+end


### PR DESCRIPTION
- ユーザー登録用の統合テストを生成

`$ rails generate integration_test users_signup`

リソース名は複数形ということを意識して`users_signup`としている。

- フォーム送信のテストの実装

フォームの送信が正しくできていることを確認するために、正しい情報が入力されてなかったときにユーザー登録がされないことをテストする。

→ 送信の前後に`User.count`の値が変化しないことをテストできればいい。

- 実際に記述していく

```
class UsersSignupTest < ActionDispatch::IntegrationTest

  test "invalid signup information" do
    get signup_path
    assert_no_difference 'User.count' do
      post users_path, params: { user: { name:  "",
                                         email: "user@invalid",
                                         password:              "foo",
                                         password_confirmation: "bar" } }
    end
    assert_template 'users/new'
  end
end
```

1. `signup`ページでの処理だから`get signup_path`で呼び出す

2. `assert_no_difference`で送信の前後で`User.count`が変化していないことを確認

```
before_count = User.count
post users_path, ...
after_count  = User.count
assert_equal before_count, after_count
```

↑ の記述と同じ

3. 送信時の受け取り処理（`post`）を擬似的に作成

```
post users_path, params: {
        user: {
          name: "",
          email: "user@invalid",
          password: "foo",
          password_confirmation: "bar"
        }
}
```

4. 送信失敗時にはnewアクションが再描画されるからそれも記述（`assert_template 'users/new'`）


5. テストを実行（`GREEN`）