### PR TITLE
登録成功のテスト

### DIFF
--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -18,4 +18,20 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'div#error_explanation'
     assert_select 'div.alert'
   end
+
+  test "success signup information" do
+    get signup_path
+    assert_difference "User.count", 1 do
+      post users_path, params: {
+        user: {
+          name:  "Example User",
+          email: "user@example.com",
+          password: "password",
+          password_confirmation: "password"
+        }
+      }
+    end
+    follow_redirect!
+    assert_template 'users/show'
+  end
 end


### PR DESCRIPTION
### 登録成功のテスト

登録の前後で`User.count`が変化していることをテストする。

- テストを記述する（`test/integration/users_signup_test.rb`）

 ```
test "valid signup information" do
    get signup_path
    assert_difference 'User.count', 1 do
      post users_path, params: { user: { name:  "Example User",
                                         email: "user@example.com",
                                         password:              "password",
                                         password_confirmation: "password" } }
    end
    follow_redirect!
    assert_template 'users/show'
  end
```

`assert_difference 'User.count', 1 `で`User.count`の差異か1のときに成功するようになっている。

`post`送信する仮のデータを記述（成功するパターンの情報）

`follow_redirect!`でPOST送信の結果によって指定のリダイレクト先に移動させる。
↑ 今回は`assert_template 'users/show'`で`show`アクションに飛ぶようになっている。