### PR TITLE
フラッシュメッセージの表示とテスト

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,9 +5,9 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
-
+      
     else
-
+      flash.now[:danger] = 'Invalid email/password combination'
       render 'new'
     end
   end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class UsersLoginTest < ActionDispatch::IntegrationTest
+  
+  test "login with invalid information" do
+    get login_path
+    assert_template 'sessions/new'
+    post login_path, params: { session: { email: "", password: "" } }
+    assert_template 'sessions/new'
+    assert_not flash.empty?
+    get root_path
+    assert flash.empty?
+  end
+end


### PR DESCRIPTION
- ログイン失敗時にフラッシュメッセージを表示（`app/controllers/sessions_controller.rb`）

```
def create
    user = User.find_by(email: params[:session][:email].downcase)
    if user && user.authenticate(params[:session][:password])
      # ユーザーログイン後にユーザー情報のページにリダイレクトする
    else
      flash[:danger] = 'Invalid email/password combination' # 本当は正しくない
      render 'new'
    end
end
```

Webサイトのレイアウトで既に追加されているので`flash[:danger]`で表示できる。

このままだとページ遷移したときにもフラッシュメッセージが表示されるというバグが発生している。

- フラッシュメッセージのテスト（`test/integration/users_login_test.rb`）

バグの解消のためにエラーを確認するためのテストコードを記述していく。

`$ rails generate integration_test users_login`

```
class UsersLoginTest < ActionDispatch::IntegrationTest

test "login with invalid information" do
    get login_path　# 1
    assert_template 'sessions/new'　# 2
    post login_path, params: { session: { email: "", password: "" } }　# 3
    assert_template 'sessions/new'　# 4
    assert_not flash.empty?　# 4
    get root_path　# 5
    assert flash.empty?　# 6
  end
end
```

1. ログイン用のパスを開く
2. 新しいセッションのフォームが正しく表示されたことを確認する
3. わざと無効なparamsハッシュを使ってセッション用パスにPOSTする
4. 新しいセッションのフォームが再度表示され、フラッシュメッセージが追加されることを確認する
5. 別のページ（Homeページなど） にいったん移動する
6. 移動先のページでフラッシュメッセージが表示されていないことを確認する

これでテストを確認（`$ rails test test/integration/users_login_test.rb`）しても失敗することがわかる（`RED`）。

- 正しい処理を記述（`app/controllers/sessions_controller.rb`）

```
def create
    user = User.find_by(email: params[:session][:email].downcase)
    if user && user.authenticate(params[:session][:password])
      # ユーザーログイン後にユーザー情報のページにリダイレクトする
    else
      flash.now[:danger] = 'Invalid email/password combination'
      render 'new'
    end
end
```

`flash.now`を利用することでフラッシュメッセージを他のリクエストによって消滅させることができるようになる。

これをテストで確認（`$ rails test test/integration/users_login_test.rb`）すると成功する（`GREEN`）。