### PR TITLE
ログインレイアウトのテスト

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,9 @@ class User < ApplicationRecord
     validates :email, presence: true, length: { maximum:255 }, format: { with: VALID_EMAIL_REGEX }, uniqueness: true
     has_secure_password
     validates :password, presence: true, length: { minimum: 6 }
+
+    def User.digest(string)
+        cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
+        BCrypt::Password.create(string, cost: cost)
+    end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,4 @@
+michael:
+  name: Michael Example
+  email: michael@example.com
+  password_digest: <%= User.digest('password') %>

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class UsersLoginTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:michael)
+  end
   
   test "login with invalid information" do
     get login_path
@@ -10,5 +14,20 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_not flash.empty?
     get root_path
     assert flash.empty?
+  end
+
+  test "success login with invalid information" do
+    get login_path
+    post login_path, params: {
+      session: {
+        email: @user.email,
+        password: 'password'
+      }
+    }
+    assert_redirected_to @user
+    follow_redirect!
+    assert_select "a[href=?]", login_path, count: 0
+    assert_select "a[href=?]", logout_path
+    assert_select "a[href=?]", user_path(@user)
   end
 end


### PR DESCRIPTION
### テストの手順

1. ログイン用のパスを開く
2. セッション用パスに有効な情報をpostする
3. ログイン用リンクが表示されなくなったことを確認する
4. ログアウト用リンクが表示されていることを確認する
5. プロフィール用リンクが表示されていることを確認する

- テスト用データをfixtureに作成する

まずはbcryptパスワードが作成される方法を同じようにハッシュ値を返すメソッドを追加する必要がある（`app/models/user.rb`）。

```
def User.digest(string)
    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                  BCrypt::Engine.cost
    BCrypt::Password.create(string, cost: cost)
end
```

このメソッドを使用することで、fixtureで作成するパスワードの文字列をもとに必要なハッシュ値に返すことができる。

これを用いてユーザーログインのテストで使うfixtureを作成する（`test/fixtures/users.yml`）。

```
michael:
  name: Michael Example
  email: michael@example.com
  password_digest: <%= User.digest('password') %>
```

これで作成したfixtureを`user = users(:michael)`のように使用することができるようになる。

- 実際のテストを記述（`test/integration/users_login_test.rb`）

```
def setup
    @user = users(:michael)
end

test "login with valid information" do
    get login_path　# 1
    post login_path, params: { session: { email:    @user.email,
                                          password: 'password' } }　# 2
    assert_redirected_to @user
    follow_redirect!
    assert_template 'users/show'
    assert_select "a[href=?]", login_path, count: 0　# 3
    assert_select "a[href=?]", logout_path　# 4
    assert_select "a[href=?]", user_path(@user)　# 5
end
```

`setup`メソッドで`@user`変数にfixtureで作成した`:michael`を代入している。

`assert_select "a[href=?]", login_path, count: 0`では`login_path`の数が0になったことで`login_path`が表示されなくなったことを表している。