### PR TITLE
remember_digestの追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+    attr_accessor :remember_token
     before_save { email.downcase! }
     validates :name, presence: true, length: { maximum: 50 }
     VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
@@ -9,5 +10,14 @@ class User < ApplicationRecord
     def User.digest(string)
         cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
         BCrypt::Password.create(string, cost: cost)
+    end
+
+    def User.new_token
+        SecureRandom.urlsafe_base64
+    end
+
+    def remember
+        self.remember_token = User.new_token
+        update_attribute(:remember_digest, User.digest(remember_token))
     end
 end

--- a/db/migrate/20210130114535_add_remember_digest_to_users.rb
+++ b/db/migrate/20210130114535_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_25_141415) do
+ActiveRecord::Schema.define(version: 2021_01_30_114535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2021_01_25_141415) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
### 永続的にセッションが維持できるようにする

1. 記憶トークンにはランダムな文字列を生成して用いる。
2. ブラウザのcookiesにトークンを保存するときには、有効期限を設定する。
3. トークンはハッシュ値に変換してからデータベースに保存する。
4. ブラウザのcookiesに保存するユーザーIDは暗号化しておく。
5. 永続ユーザーIDを含むcookiesを受け取ったら、そのIDでデータベースを検索し、記憶トークンのcookiesがデータベース内のハッシュ値と一致することを確認する。

- 記憶トークン用のカラムを追加する

<img width="274" alt="スクリーンショット 2021-01-30 21 00 17" src="https://user-images.githubusercontent.com/60529151/106355870-2a13e080-633e-11eb-9d69-ef1d25ed6021.png">

`remember_digest`をUserモデルに追加する必要がある。

`$ rails generate migration add_remember_digest_to_users remember_digest:string`

```
class AddRememberDigestToUsers < ActiveRecord::Migration[6.0]
  def change
    add_column :users, :remember_digest, :string
  end
end
```

変更点はないからそのままデータベースに登録する。

`$ rails db:migrate`

- トークン生成用メソッドを追加（app/models/user.rb）

```
class User < ApplicationRecord
 ・・・
  def User.new_token
    SecureRandom.urlsafe_base64
  end
end
```

`SecureRandom`モジュールにある`urlsafe_base64`メソッドでランダムな文字列を作成して記憶トークンとして生成する。

- rememberメソッドをUserモデルに追加する（app/models/user.rb）

```
class User < ApplicationRecord
  attr_accessor :remember_token
 
 ・・・
  
  def remember
    self.remember_token = User.new_token
    update_attribute(:remember_digest, User.digest(remember_token))
  end
end
```

仮想の`:remember_token`を作成し、その中に新しく作成した記憶トークンを随時更新してく。