### PR TITLE
バグの解消

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     redirect_to root_url
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
     end
 
     def authenticated?(remember_token)
+        return false if remember_digest.nil?
         BCrypt::Password.new(remember_digest).is_password?(remember_token)
     end
 

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -40,6 +40,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     delete logout_path
     assert_not is_logged_in?
     assert_redirected_to root_url
+    delete logout_path
     follow_redirect!
     assert_select "a[href=?]", login_path
     assert_select "a[href=?]", logout_path, count: 0

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -68,4 +68,8 @@ class UserTest < ActiveSupport::TestCase
     @user.password = @user.password_confirmation = "a" * 5
     assert_not @user.valid?
   end
+
+  test "authenticated? should return false for a user with nil digest" do
+    assert_not @user.authenticated?('')
+  end
 end


### PR DESCRIPTION
### 発生しているバグの確認

1. 同じログイン状態で複数個のタブやウィンドウを開いているときに、ひとつでログアウトするともう一方がログアウトするときにエラーになる。
2. 同じログイン状態で複数のブラウザを開いているときに、ひとつでログアウトするともう一方がログアウトするときにエラーになる。

- 1をテストする（`test/integration/users_login_test.rb`）

```
class UsersLoginTest < ActionDispatch::IntegrationTest
  .
  .
  .
  test "login with valid information followed by logout" do
    get login_path
    post login_path, params: { session: { email:    @user.email,
                                          password: 'password' } }
    assert is_logged_in?
    assert_redirected_to @user
    follow_redirect!
    assert_template 'users/show'
    assert_select "a[href=?]", login_path, count: 0
    assert_select "a[href=?]", logout_path
    assert_select "a[href=?]", user_path(@user)
    delete logout_path
    assert_not is_logged_in?
    assert_redirected_to root_url
    delete logout_path
    follow_redirect!
    assert_select "a[href=?]", login_path
    assert_select "a[href=?]", logout_path,      count: 0
    assert_select "a[href=?]", user_path(@user), count: 0
  end
end
```

1度ログアウトをして再度ログアウトしたとき（`delete logout_path`）のテストを実行している。

現段階ではエラーのままだから失敗する（`RED`）。

- ログイン中の場合のみログアウト（`app/controllers/sessions_controller.rb`）

```
class SessionsController < ApplicationController
  .
  .
  .
  def destroy
    log_out if logged_in?
    redirect_to root_url
  end
end
```

ログイン状態を判定している`logged_in?`でログイン中かどうかを判定してログアウトを実行するようにしている。

これで1のテストが成功する（`GREEN`）。

- 2をテストする（`test/models/user_test.rb`）

Userモデルの`authenticated?`が空のときに判定が`false`になることを確かめればいい。

```
class UserTest < ActiveSupport::TestCase

  def setup
    @user = User.new(name: "Example User", email: "user@example.com",
                     password: "foobar", password_confirmation: "foobar")
  end
  .
  .
  .
  test "authenticated? should return false for a user with nil digest" do
    assert_not @user.authenticated?('')
  end
end
```

`BCrypt::Password.new()`は`nil`だとエラーになるから、テストは失敗する（`RED`）。

- ダイジェストが存在しない場合にも対応（`app/models/user.rb`）

```
class User < ApplicationRecord
  .
  .
  .
  def authenticated?(remember_token)
    return false if remember_digest.nil?
    BCrypt::Password.new(remember_digest).is_password?(remember_token)
  end

  # ユーザーのログイン情報を破棄する
  def forget
    update_attribute(:remember_digest, nil)
  end
end
```

`remember_digest`が`nil`のときは`false`を返すことでエラーが解消できる（`GREEN`）。