### PR TITLE
ログインの認証

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:edit, :update]
 
   def show
     @user = User.find(params[:id])
@@ -38,4 +39,11 @@ class UsersController < ApplicationController
     def user_params  
       params.require(:user).permit(:name, :email, :password, :password_confirmation)
     end
+
+  def logged_in_user
+    unless logged_in?
+      flash[:danger] = "Please log in."
+      redirect_to login_path
+    end
+  end
 end

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -7,6 +7,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
   end
 
   test "unsuccessful edit" do
+    log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
     patch user_path(@user), params: {
@@ -22,6 +23,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
   end
 
   test "successful edit" do
+    log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
     name = "Foo Bar"
@@ -39,5 +41,22 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     @user.reload
     assert_equal name, @user.name
     assert_equal email, @user.email
+  end
+
+  test "should redirect edit when not logged in" do
+    get edit_user_path(@user)
+    assert_not flash.empty?
+    assert_redirected_to login_path
+  end
+
+  test "should redirect update when not logged in" do
+    patch user_path(@user), params: {
+      user: {
+        name: @user.name,
+        email: @user.email
+      }
+    }
+    assert_not flash.empty?
+    assert_redirected_to login_path
   end
 end


### PR DESCRIPTION
- beforeフィルターにlogged_in_userを追加（`app/controllers/users_controller.rb`）

```
class UsersController < ApplicationController
  before_action :logged_in_user, only: [:edit, :update]
  .
  .
  .
  def logged_in_user
    unless logged_in?
      flash[:danger] = "Please log in."
      redirect_to login_url
    end
  end
end
```

`before_action`メソッドで`logged_in_user`を他の処理が実行される直前に実行させる。

ログインしていなかったら（`unless logged_in? ・・・ end`）フラッシュメッセージとログインページにリダレクトするようになる。

- テストユーザーでログイン（`test/integration/users_edit_test.rb`）

テストユーザーでログインを実行させるときは統合テスト用の`log_in_as`ヘルパーを使用する。

```
class UsersEditTest < ActionDispatch::IntegrationTest

  def setup
    @user = users(:michael)
  end

  test "unsuccessful edit" do
    log_in_as(@user)
    get edit_user_path(@user)
    .
    .
    .
  end

  test "successful edit" do
    log_in_as(@user)
    get edit_user_path(@user)
    .
    .
    .
  end
end
```

- beforeフィルターをコメントアウトしてテストを確認する（`app/controllers/users_controller.rb`、`test/controllers/users_controller_test.rb`）

```
class UsersController < ApplicationController
  # before_action :logged_in_user, only: [:edit, :update]
  .
  .
  .
end
```

```
class UsersControllerTest < ActionDispatch::IntegrationTest

  def setup
    @user = users(:michael)
  end
  .
  .
  .
  test "should redirect edit when not logged in" do
    get edit_user_path(@user)
    assert_not flash.empty?
    assert_redirected_to login_url
  end

  test "should redirect update when not logged in" do
    patch user_path(@user), params: { user: { name: @user.name,
                                              email: @user.email } }
    assert_not flash.empty?
    assert_redirected_to login_url
  end
end
```

`log_in_as`ヘルパーを使用をしていないからログインしていないのにユーザーにアクセスしている状態を再現できる。

この状態だとテストが失敗（`RED`）するからコメントアウトを解除してテストの成功を確認する（`GREEN`）。