### PR TITLE
正しいユーザーの取得をテストする

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :logged_in_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update]
 
   def show
     @user = User.find(params[:id])
@@ -45,5 +46,10 @@ class UsersController < ApplicationController
       flash[:danger] = "Please log in."
       redirect_to login_path
     end
+  end
+
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to(root_url) unless current_user?(@user)
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -22,6 +22,10 @@ module SessionsHelper
         end
     end
 
+    def current_user?(user)
+        user && user == current_user
+    end
+
     def logged_in?
         !current_user.nil?
     end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,3 +2,8 @@ michael:
   name: Michael Example
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
+
+archer:
+  name: Sterling Archer
+  email: duchess@example.gov
+  password_digest: <%= User.digest('password') %>

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -4,6 +4,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
 
   def setup
     @user = users(:michael)
+    @other_user = users(:archer)
   end
 
   test "unsuccessful edit" do
@@ -58,5 +59,24 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     }
     assert_not flash.empty?
     assert_redirected_to login_path
+  end
+
+  test "should redirect edit when logged in as wrong user" do
+    log_in_as(@other_user)
+    get edit_user_path(@user)
+    assert flash.empty?
+    assert_redirected_to root_url
+  end
+
+  test "should redirect update when logged in as wrong user" do
+    log_in_as(@other_user)
+    patch user_path(@user), params: {
+      user: {
+        name: @user.name,
+        email: @user.email
+      }
+    }
+    assert flash.empty?
+    assert_redirected_to root_url
   end
 end


### PR DESCRIPTION
fixtureに新たにサンプルユーザーを追加して2人目のユーザーが1人目のユーザーにアクセスしようとしたときにrootにリダイレクトされるようなテストを実行させる。

-  fixtureファイルに２人目のユーザーを追加（`test/fixtures/users.yml`）

```
michael:
  name: Michael Example
  email: michael@example.com
  password_digest: <%= User.digest('password') %>

archer:
  name: Sterling Archer
  email: duchess@example.gov
  password_digest: <%= User.digest('password') %>
```

- 間違ったユーザーが編集しようとしたときのテスト（`test/controllers/users_controller_test.rb`）

```
class UsersControllerTest < ActionDispatch::IntegrationTest

  def setup
    @user       = users(:michael)
    @other_user = users(:archer)
  end
  .
  .
  .
  test "should redirect edit when logged in as wrong user" do
    log_in_as(@other_user)
    get edit_user_path(@user)
    assert flash.empty?
    assert_redirected_to root_url
  end

  test "should redirect update when logged in as wrong user" do
    log_in_as(@other_user)
    patch user_path(@user), params: { user: { name: @user.name,
                                              email: @user.email } }
    assert flash.empty?
    assert_redirected_to root_url
  end
end
```

`@other_user`でログインしている状態（`log_in_as(@other_user)`）で`@user`の編集・更新をしようとしたときに`root_path`にリダイレクトしてフラッシュメッセージを表示させる。

現段階では判定ができていないから失敗する（`RED`）。

- beforeフィルターを使って編集/更新ページを保護（`app/controllers/users_controller.rb`）

```
class UsersController < ApplicationController
  before_action :logged_in_user, only: [:edit, :update]
  before_action :correct_user,   only: [:edit, :update]
  .
  .
  .
  def edit
  end

  def update
    if @user.update(user_params)
      flash[:success] = "Profile updated"
      redirect_to @user
    else
      render 'edit'
    end
  end
  .
  .
  .
  private

    def user_params
      params.require(:user).permit(:name, :email, :password,
                                   :password_confirmation)
    end

    def logged_in_user
      unless logged_in?
        flash[:danger] = "Please log in."
        redirect_to login_url
      end
    end

    def correct_user
      @user = User.find(params[:id])
      redirect_to(root_url) unless @user == current_user
    end
end
```

`@user`と`current_user`ユーザーが一致しない場合はrootにリダイレクトできるようにする。

これでテストが成功する（`GREEN`）。

- ヘルパーにcurrent_user?メソッドに追加して簡略化する（`app/helpers/sessions_helper.rb`、`app/controllers/users_controller.rb`）

```
module SessionsHelper
 ・
 ・
 ・
  def current_user
    if (user_id = session[:user_id])
      @current_user ||= User.find_by(id: user_id)
    elsif (user_id = cookies.signed[:user_id])
      user = User.find_by(id: user_id)
      if user && user.authenticated?(cookies[:remember_token])
        log_in user
        @current_user = user
      end
    end
  end

  def current_user?(user)
    user && user == current_user
  end
  .
  .
  .
end
```

```
class UsersController < ApplicationController
  before_action :logged_in_user, only: [:edit, :update]
  before_action :correct_user,   only: [:edit, :update]
  .
  .
  .
  private
  .
  .
  .
    def correct_user
      @user = User.find(params[:id])
      redirect_to(root_url) unless current_user?(@user)
    end
end
```

これで`correct_user`かどうかの判定を汎用的に使えるようになった。