### PR TITLE
フレンドリーフォワーディング

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
     if @user&.authenticate(params[:session][:password])
       log_in @user
       params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
-      redirect_to @user
+      redirect_back_or @user
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,6 +43,7 @@ class UsersController < ApplicationController
 
     def logged_in_user
       unless logged_in?
+        store_location
         flash[:danger] = "Please log in."
         redirect_to login_path
       end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -41,4 +41,13 @@ module SessionsHelper
         session.delete(:user_id)
         @current_user = nil
     end
+
+    def redirect_back_or(default)
+        redirect_to(session[:forwarding_url] || default)
+        session.delete(:forwarding_url)
+    end
+
+    def store_location
+        session[:forwarding_url] = request.original_url if request.get?
+    end
 end

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -79,4 +79,25 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     assert flash.empty?
     assert_redirected_to root_url
   end
+
+  test "successful edit with friendly forwarding" do
+    get edit_user_path(@user)
+    log_in_as(@user)
+    assert_redirected_to edit_user_path(@user)
+    name = "Foo Bar"
+    email = "foo@bar.com"
+    patch user_path(@user), params: {
+      user: {
+        name: name,
+        email: email,
+        password: "",
+        password_confirmation: ""
+      }
+    }
+    assert_not flash.empty?
+    assert_redirected_to @user
+    @user.reload
+    assert_equal name, @user.name
+    assert_equal email, @user.email
+  end
 end


### PR DESCRIPTION
ログインしていない状態で編集ページにいくとログインページにリダイレクトされてログインしたら編集ページにリダイレクトするようにしたい。

↑ 今はログイン後にhomeページにリダイレクトされるようになっている。

- フレンドリーフォワーディングのテスト（`test/integration/users_edit_test.rb`）

```
class UsersEditTest < ActionDispatch::IntegrationTest

  def setup
    @user = users(:michael)
  end
  .
  .
  .
  test "successful edit with friendly forwarding" do
    get edit_user_path(@user)
    log_in_as(@user)
    assert_redirected_to edit_user_url(@user)
    name  = "Foo Bar"
    email = "foo@bar.com"
    patch user_path(@user), params: { user: { name:  name,
                                              email: email,
                                              password:              "",
                                              password_confirmation: "" } }
    assert_not flash.empty?
    assert_redirected_to @user
    @user.reload
    assert_equal name,  @user.name
    assert_equal email, @user.email
  end
end
```

現段階ではテストが失敗する（`RED`）。

- フレンドリーフォワーディングの実装（`app/helpers/sessions_helper.rb`）

```
module SessionsHelper
  .
  .
  .
  def redirect_back_or(default)
    redirect_to(session[:forwarding_url] || default)
    session.delete(:forwarding_url)
  end

  def store_location
    session[:forwarding_url] = request.original_url if request.get?
  end
end
```

`store_location`でアクセスしたURLを記憶しておく。
→ セッションの`forwarding_url`にURLを記憶する。
→ リクエスト先のURLは`request.original_url`で取得できる。
→ `GET`じゃないとエラーになるから条件にいれる（`request.get?`）。

`redirect_back_or`でリダイレクト先を決めている。
→ `forwarding_url`があると`forwarding_url`でなければ引数のURLにリダイレクトする。

- ログインユーザー用beforeフィルターにstore_locationを追加（`app/controllers/users_controller.rb`）

```
class UsersController < ApplicationController
  before_action :logged_in_user, only: [:edit, :update]
  before_action :correct_user,   only: [:edit, :update]
  .
  .
  .
  def edit
  end
  .
  .
  .
  private

   ・・・

    def logged_in_user
      unless logged_in?
        store_location
        flash[:danger] = "Please log in."
        redirect_to login_url
      end
    end
 ・・・
end
```

ログインを確認する`logged_in_user`メソッドで`store_location`を追加してURLを記憶している。

- フレンドリーフォワーディングを備えたcreateアクション（`app/controllers/sessions_controller.rb`）

```
class SessionsController < ApplicationController
  .
  .
  .
  def create
    user = User.find_by(email: params[:session][:email].downcase)
    if user && user.authenticate(params[:session][:password])
      log_in user
      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
      redirect_back_or @user
    else
      flash.now[:danger] = 'Invalid email/password combination'
      render 'new'
    end
  end
  .
  .
  .
end
```

`redirect_back_or`を追加することでできる。