### PR TITLE
adminカラムの追加

### DIFF
--- a/db/migrate/20210202072708_add_admin_to_users.rb
+++ b/db/migrate/20210202072708_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_30_114535) do
+ActiveRecord::Schema.define(version: 2021_02_02_072708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2021_01_30_114535) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
     t.string "remember_digest"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,8 @@ User.create!(
     name: "Example User",
     email: "example@railstutorial.org",
     password: "foobar",
-    password_confirmation: "foobar"
+    password_confirmation: "foobar",
+    admin: true
 )
 
 99.times do |n|


### PR DESCRIPTION
管理者ユーザーを識別するために`admin`属性を追加して管理する。

論理値として`admin?`で扱うことができる形にする。

- boolean型のadmin属性をUserに追加するマイグレーション（`db/migrate/[timestamp]_add_admin_to_users.rb`）

`$ rails generate migration add_admin_to_users admin:boolean`

```
class AddAdminToUsers < ActiveRecord::Migration[6.0]
  def change
    add_column :users, :admin, :boolean, default: false
  end
end
```

デフォルトの状態は`false`で設定しておく必要がある。

データベースのカラムに追加する（マイグレーション）。

`$ rails db:migrate`

- サンプルデータ生成タスクに管理者を1人追加（`db/seeds.rb`）

```
User.create!(name:  "Example User",
             email: "example@railstutorial.org",
             password:              "foobar",
             password_confirmation: "foobar",
             admin: true)

99.times do |n|
  name  = Faker::Name.name
  email = "example-#{n+1}@railstutorial.org"
  password = "password"
  User.create!(name:  name,
               email: email,
               password:              password,
               password_confirmation: password)
end
```

リセットしてマイグレートで変更を反映させる。

```
$ rails db:migrate:reset
$ rails db:seed
```

ユーザーの更新を行う際に管理者の権限が使えるのはよくないことだから、`user_params`の`permit`で`admin`属性を許可しないようにする。

```
def user_params  
      params.require(:user).permit(:name, :email, :password, :password_confirmation)
end
```